### PR TITLE
"nodeMaps" "url" ist nicht mehr erreichbar

### DIFF
--- a/altdorf.freifunk.net.json
+++ b/altdorf.freifunk.net.json
@@ -67,7 +67,7 @@
             "mapType": "geographical"
         },
         {
-            "url": "https://data.tecff.de/nodelist.json",
+            "url": "https://map.tecff.de/hopglass-server/mv1/nodelist.json",
             "interval": "1 minute",
             "technicalType": "nodelist"
         }


### PR DESCRIPTION
"https://data.tecff.de/nodelist.json" gibt es nicht mehr.
"https://map.tecff.de/hopglass-server/mv1/nodelist.json"
gibt es noch nicht. dito landshut.
